### PR TITLE
Use serial ID for attach_id and clarify documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ If you use **FRETraj** in your work please refer to the following paper:
 - F.D. Steffen, R.K.O. Sigel, R. Börner, *Bioinformatics* **2021**. [![](https://img.shields.io/badge/DOI-10.1093/bioinformatics/btab615-blue.svg)](https://doi.org/10.1093/bioinformatics/btab615)
 
 ### Additional readings
+- F.D. Steffen, R.A. Cunha, R.K.O. Sigel, R. Börner, *Nucleic Acids Res.* **2024**, *52*, e59.
 - F.D. Steffen, R.K.O. Sigel, R. Börner, *Phys. Chem. Chem. Phys.* **2016**, *18*, 29045-29055.
 - S. Kalinin, T. Peulen, C.A.M. Seidel et al. *Nat. Methods*, **2012**, *9*, 1218-1225.
 - T. Eilert, M. Beckers, F. Drechsler, J. Michaelis, *Comput. Phys. Commun.*, **2017**, *219*, 377–389.

--- a/docs/getting_started/acv_calculation.md
+++ b/docs/getting_started/acv_calculation.md
@@ -32,7 +32,21 @@ In the following the most important settings and functionalities of FRETraj for 
     ```{hint}
     If you already have a JSON-formatted [parameter file](../background/parameter_file) you can load this file with the **Load Param** button and proceed directly to the last step [compute ACV](compute-acv).
     ```
-4. **atom ID**: select the attachment atom on the biomolecule by its serial ID
+4. **atom ID**: select the attachment atom on the biomolecule by its 1-based index (i.e. PyMOL's index selection, see Note below). 
+     ```{note}
+    - [mdtraj](https://www.mdtraj.org/1.9.8.dev0/atom_selection.html) uses two different atom selections:
+        - `serial` refers to the atom identifier (number present in columns 7-11 of the PDB file), e.g. `[a.serial for a in dna.topology.atoms][0]` returns `1`.
+        - `index` refers to the 0-based index, e.g. `[a.index for a in dna.topology.atoms]` returns `0`. When using `atom_slice` the selection is re-indexed, i.e. `[a.index for a in dna.atom_slice([2]).topology.atoms]` returns `0` but the `serial` is maintained, i.e. `[a.serial for a in dna.atom_slice([2]).topology.atoms]` returns `3`).
+    - PDBs usually are 1-based indexed. PyMOL uses the following identifiers:
+        - `id` refers to the [atom identifier](https://pymol.org/dokuwiki/doku.php?id=selection:rank) (number present in columns 7-11 of the PDB file) which correspponds to mdtraj's `serial`.
+        - `index` refers to the [1-based index](https://pymol.org/dokuwiki/doku.php?id=selection:index))
+        - `rank` refers to the [0-based index](https://pymol.org/dokuwiki/doku.php?id=selection:rank) which corresponds to mdtraj's indexing
+    ```
+
+    ``` {admonition} Internal indexing in FRETraj 0.2.11
+    In FRETraj ≤ 0.2.10 we internally indexed `attach_id` using mdtraj's `index` (`attach_id_mdtraj`) while the user selected atoms using 1-based indexing (i.e. PyMOL's `index`). With FRETRaj ≥ 0.2.11 we now switch to internally use PyMOL's mdtraj's `serial` / PyMOL's `id` for `attach_id` to keep consistent atom identifiers upon slicing. For PDBs starting with `id=1` this change does not affect the user.
+    ```
+
 5. **state**: select a different state of the PDB file
 6. Add the new position to the label dropdown by pressing on ▶️
     ```{note}

--- a/docs/getting_started/acv_calculation.md
+++ b/docs/getting_started/acv_calculation.md
@@ -32,19 +32,19 @@ In the following the most important settings and functionalities of FRETraj for 
     ```{hint}
     If you already have a JSON-formatted [parameter file](../background/parameter_file) you can load this file with the **Load Param** button and proceed directly to the last step [compute ACV](compute-acv).
     ```
-4. **atom ID**: select the attachment atom on the biomolecule by its 1-based index (i.e. PyMOL's index selection, see Note below). 
+4. **atom ID**: select the attachment atom on the biomolecule by its serial atom ID (i.e. the ID of the atom given in the DPB file in columns 7-11, see *Note* below). 
      ```{note}
-    - [mdtraj](https://www.mdtraj.org/1.9.8.dev0/atom_selection.html) uses two different atom selections:
-        - `serial` refers to the atom identifier (number present in columns 7-11 of the PDB file), e.g. `[a.serial for a in dna.topology.atoms][0]` returns `1`.
-        - `index` refers to the 0-based index, e.g. `[a.index for a in dna.topology.atoms]` returns `0`. When using `atom_slice` the selection is re-indexed, i.e. `[a.index for a in dna.atom_slice([2]).topology.atoms]` returns `0` but the `serial` is maintained, i.e. `[a.serial for a in dna.atom_slice([2]).topology.atoms]` returns `3`).
-    - PDBs usually are 1-based indexed. PyMOL uses the following identifiers:
-        - `id` refers to the [atom identifier](https://pymol.org/dokuwiki/doku.php?id=selection:rank) (number present in columns 7-11 of the PDB file) which correspponds to mdtraj's `serial`.
+    - PyMOL uses the following identifiers:
+        - `id` refers to the [atom identifier](https://pymol.org/dokuwiki/doku.php?id=selection:rank) (number present in columns 7-11 of the PDB file) which correspponds to mdtraj's `serial` (see below). Usually PDBs start with `id=1` but this may vary if the PDB is sliced.
         - `index` refers to the [1-based index](https://pymol.org/dokuwiki/doku.php?id=selection:index))
-        - `rank` refers to the [0-based index](https://pymol.org/dokuwiki/doku.php?id=selection:rank) which corresponds to mdtraj's indexing
+        - `rank` refers to the [0-based index](https://pymol.org/dokuwiki/doku.php?id=selection:rank) which corresponds to mdtraj's `index` (see below)
+    - [mdtraj](https://www.mdtraj.org/1.9.8.dev0/atom_selection.html) exposes two atom selection options:
+        - `serial` refers to the atom identifier (number present in columns 7-11 of the PDB file), e.g. `[a.serial for a in dna.topology.atoms][0]` returns `1`.
+        - `index` refers to the 0-based indexe.g. `[a.index for a in dna.topology.atoms]` returns `0`. Note that, when using `atom_slice` the selection is re-indexed, i.e. `[a.index for a in dna.atom_slice([2]).topology.atoms]` returns `0` but the `serial` is maintained, i.e. `[a.serial for a in dna.atom_slice([2]).topology.atoms]` still returns `3`, given that the original PDB started with `id=1`).
     ```
 
-    ``` {admonition} Internal indexing in FRETraj 0.2.11
-    In FRETraj ≤ 0.2.10 we internally indexed `attach_id` using mdtraj's `index` (`attach_id_mdtraj`) while the user selected atoms using 1-based indexing (i.e. PyMOL's `index`). With FRETRaj ≥ 0.2.11 we now switch to internally use PyMOL's mdtraj's `serial` / PyMOL's `id` for `attach_id` to keep consistent atom identifiers upon slicing. For PDBs starting with `id=1` this change does not affect the user.
+    ``` {admonition} Internal indexing in FRETraj
+    In FRETraj we use `attach_id` to refer to the PyMOL's atom `id` / mdtraj's `serial`. Internally, we match the atom serial `id` to mdtraj's 0-based `index` (`attach_id_mdtraj`). This ensures consistency in `attach_id` when the PDB is sliced.
     ```
 
 5. **state**: select a different state of the PDB file

--- a/src/fretraj/cloud.py
+++ b/src/fretraj/cloud.py
@@ -53,7 +53,7 @@ _label_dict = {
             "transparent_AV": (bool, True),
         }
     },
-    "Distance": {"pd_key": {"R0": ((int, float), None), "n_dist": (int, 10 ** 6)}},
+    "Distance": {"pd_key": {"R0": ((int, float), None), "n_dist": (int, 10**6)}},
 }
 
 _label_dict_vals = {
@@ -872,18 +872,22 @@ class Volume:
                         self.acv = None
                     else:
                         try:
-                            if self.attach_id < 1 or self.attach_id > self.n_atoms:
-                                raise IndexError
-                        except IndexError:
+                            if self.attach_id not in [a.serial for a in self.structure.top.atoms]:
+                                raise ValueError
+                        except ValueError:
                             print(
-                                "The attachment position {:d} is out of range, select an index within 1 - {:d}".format(
-                                    self.attach_id, self.n_atoms
+                                "The attachment ID {:d} is not present in the PDB file (id columns 7-11)".format(
+                                    self.attach_id
                                 )
                             )
                             self.av = None
                             self.acv = None
                         else:
-                            self.attach_id_mdtraj = labels["Position"][site]["attach_id"] - 1
+                            self.attach_id_mdtraj = [
+                                a.index
+                                for a in self.structure.top.atoms
+                                if a.serial == labels["Position"][site]["attach_id"]
+                            ][0]
                             self.resi_atom = self.structure.top.atom(self.attach_id_mdtraj)
 
                             self.av = self.calc_av(self.use_LabelLib)
@@ -894,7 +898,7 @@ class Volume:
                             except ValueError:
                                 if verbose:
                                     print(
-                                        "Empty Accessible volume at position {:d}. Is your attachment point buried?".format(
+                                        "Empty Accessible volume at atom ID position {:d}. Is your attachment point buried?".format(
                                             self.attach_id
                                         )
                                     )


### PR DESCRIPTION
Thank you @HamiltonGeorge for raising the issue and the implementation of your fix. This PR addresses #4.

The `attach_id` continues to refer to the serial atom `id` (columns 7-11 in the PDB file) but internally mdtraj's `serial` (corresponding to PyMOL's `id`, described [here](https://pymol.org/dokuwiki/doku.php?id=selection:id)) is matched with mdtraj's 0-based `index` (corresponds to PyMOL's `rank`, described [here](https://pymol.org/dokuwiki/doku.php?id=selection:rank)). PyMOL's `index` is [1-based](https://pymol.org/dokuwiki/doku.php?id=selection:index). The documentation is updated accordingly.